### PR TITLE
Fix formatting bug for automatic content filter

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -116,9 +116,9 @@ utils.censorBannedMarkdown = function (content) {
 	return content.replace(bannedWordsRegex, (match) => {
 		if (match.length <= 2) {
 			// Replace single-character words with "*"
-			return '**';
+			return '\\*\\*';
 		}
-		return match[0] + '*'.repeat(match.length - 2) + match.slice(-1);
+		return match[0] + '\\*'.repeat(match.length - 2) + match.slice(-1);
 	});
 };
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -102,7 +102,7 @@ describe('Topic\'s', () => {
 				content: 'apple banana grape',
 				cid: topic.categoryId,
 			}, (_, result) => {
-				assert.strictEqual(result.postData.content, 'a***e b****a grape');
+				assert.strictEqual(result.postData.content, 'a\\*\\*\\*e b\\*\\*\\*\\*a grape');
 				meta.config.bannedWords = oldValue;
 				done();
 			});
@@ -133,7 +133,7 @@ describe('Topic\'s', () => {
 				content: 'op grape',
 				cid: topic.categoryId,
 			}, (_, result) => {
-				assert.strictEqual(result.postData.content, '** grape');
+				assert.strictEqual(result.postData.content, '\\*\\* grape');
 				meta.config.bannedWords = oldValue;
 				done();
 			});


### PR DESCRIPTION
Resolves #24 

Words will automatically be starred out (e.g. apple -> a***e) when a post appears with the banned word, including text and markdown.

Files changed:

src/utils.js: edited `censorBannedMarkdown` function to have `'\\*` in the regex (or else the markdown will mistake the stars for bolding)
test/topics.js: edited test for `censorBannedMarkdown` to account for markdown

![image](https://github.com/user-attachments/assets/80817e30-4d77-4bee-b006-e3d47b34caaf)