### PR TITLE
feat: Translate feature added and doesn't break previous tests, new t…

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -79,6 +79,14 @@
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
 		</div>
+		{{{ if !posts.english }}}
+		    <div class="non-english-message">
+				<button type="submit" component="post/content/translated" class="btn btn-sm btn-light show-translated-btn"> Translate this message. </button>
+		    </div>
+		    <div class="translated-version" style="display:none;">
+		        {posts.translation}
+		    </div>
+	    {{{end}}}
 	</div>
 </div>
 

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -14,6 +14,8 @@ PostObject:
       description: A user identifier
     timestamp:
       type: number
+    english:
+      type: boolean
     deleted:
       type: boolean
     upvotes:
@@ -140,3 +142,9 @@ PostObject:
       type: boolean
     replies:
       type: number
+    additionalProperties:
+      type: object
+      properties:
+        translation:
+          nullable: true
+          type: string

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -82,6 +82,8 @@ get:
                                               type: number
                                             content:
                                               type: string
+                                            english:
+                                              type: boolean
                                             timestampISO:
                                               type: string
                                               description: An ISO 8601 formatted date string (complementing `timestamp`)
@@ -140,6 +142,10 @@ get:
                                     type: number
                                   timestamp:
                                     type: number
+                                  english:
+                                    type: boolean
+                                  translation:
+                                    type: string
                                   content:
                                     type: string
                                   timestampISO:

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -77,6 +77,8 @@ get:
                                               type: number
                                             content:
                                               type: string
+                                            english:
+                                              type: boolean
                                             timestampISO:
                                               type: string
                                               description: An ISO 8601 formatted date string (complementing `timestamp`)
@@ -142,6 +144,10 @@ get:
                                     type: number
                                   timestamp:
                                     type: number
+                                  english:
+                                    type: boolean
+                                  translation:
+                                    type: string
                                   content:
                                     type: string
                                   timestampISO:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -63,6 +63,10 @@ get:
                           type: string
                         timestamp:
                           type: number
+                        translation:
+                          type: string
+                        english:
+                          type: boolean
                         votes:
                           type: number
                         deleted:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -34,6 +34,8 @@ get:
                     description: A topic identifier
                   content:
                     type: string
+                  english:
+                    type: boolean
                   timestamp:
                     type: number
                   flagId:
@@ -64,6 +66,12 @@ get:
                     type: boolean
                   downvoted:
                     type: boolean
+                additionalProperties:
+                  type: object
+                  properties:
+                    translation:
+                      nullable: true
+                      type: string
 put:
   tags:
     - posts

--- a/public/openapi/write/posts/pid/replies.yaml
+++ b/public/openapi/write/posts/pid/replies.yaml
@@ -41,6 +41,8 @@ get:
                           type: string
                         timestamp:
                           type: number
+                        english:
+                          type: boolean
                         votes:
                           type: number
                         deleted:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -69,6 +69,7 @@ define('forum/topic', [
 		setupQuickReply();
 		handleBookmark(tid);
 		handleThumbs();
+		showTranslatedPost();
 
 		$(window).on('scroll', utils.debounce(updateTopicTitle, 250));
 
@@ -434,6 +435,19 @@ define('forum/topic', [
 		}
 	}
 
+	function showTranslatedPost() {
+		console.log('calling showTranslatedPost');
+		// When the translate button is clicked, toggle the translated version and change the translate button
+		$('.topic').on('click', '.show-translated-btn', function () {
+			$(this).closest('.non-english-message').next('.translated-version').toggle();
+			var visible = $(this).closest('.non-english-message').next('.translated-version').is(':visible');
+			if (visible) {
+				$(this).text('Hide translation.');
+			} else {
+				$(this).text('Translate this message.');
+			}
+		});
+	}
 
 	return Topic;
 });

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -10,16 +10,17 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
+const translationApi = require('../translate');
 
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
 		// This is an internal method, consider using Topics.reply instead
-		console.log('hello everyone');
 		const { uid } = data;
 		const { tid } = data;
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const [english, translatedTxt] = await translationApi.translate(data);		
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -34,6 +35,8 @@ module.exports = function (Posts) {
 			pid: pid,
 			uid: uid,
 			tid: tid,
+			english: english,
+			translation: translatedTxt,
 			content: content,
 			timestamp: timestamp,
 		};

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -58,6 +58,7 @@ module.exports = function (Posts) {
 function modifyPost(post, fields) {
 	if (post) {
 		db.parseIntFields(post, intFields, fields);
+		post.english = post.english === 'true' || post.english === undefined;
 		if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
 			post.votes = post.upvotes - post.downvotes;
 		}

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+
+module.exports.translate = async function (data) {
+    const url = `https://clients5.google.com/translate_a/t?client=dict-chrome-ex&sl=auto&tl=en&q=${encodeURIComponent(data.content)}`;
+
+    try {
+        const response = await fetch(url, {
+            method: "POST"
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP Error: ${response.status}`);
+        }
+
+        const translation_data = await response.json();
+
+        const translatedText = translation_data[0][0];
+        const detectedLanguage = translation_data[0][1];
+
+        return [detectedLanguage === "en", translatedText];
+    } catch (error) {
+        console.error("Error:", error);
+        return null;
+    }
+    
+}
+


### PR DESCRIPTION
Resolves #28 

This pull request allows all users to translate a post from (almost) any language to English. NOTE: Since the API used was free (Google Translate), there could be slightly wrong translations. 

Files changed:

node bb-theme-harmony/templates/partials/topic/post.tpl - Changed format to have a translate button if not in English

public/openapi/components/schemas/PostObject.yaml,
public/openapi/read/categories.yaml,
public/openapi/read/index.yaml,
public/openapi/read/topic/topic_id.yaml,
public/openapi/write/posts/pid.yaml,
public/openapi/write/posts/pid/replies.yaml,
public/src/client/topic.js -
All changed to store two variables: "english": boolean for if the post is english, "translation": string for the translation.

src/posts/create.js - Call and store translation API

src/translate/index.js - API function
