### PR TITLE
Made Tags that show whether a post was made by a User or an Admin and also cleaned up the admin star in the actual post

### DIFF
--- a/nodebb-theme-harmony/scss/topic.scss
+++ b/nodebb-theme-harmony/scss/topic.scss
@@ -79,22 +79,28 @@ body.template-topic {
 	}
 	
 	.admin-star {
-        width: 60px;
-        height: 60px;
-        background-color: gold;
-        clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: bold;
-        font-size: 10px;
-        color: black;
-        text-transform: uppercase;
-        text-align: right;
-        box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
-        border-radius: 5px;
-        top: 10px;
-        left: 10px;
+		width: 16px; // Tiny but visible
+		height: 16px;
+		background: linear-gradient(145deg, #3a8dde, #1e5aa6); // Modern blue gradient
+		clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 
+						   50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: white;
+		font-size: 6px;
+		text-align: center;
+		font-weight: bold;
+		text-shadow: 0px 0px 2px rgba(255, 255, 255, 0.8);
+		box-shadow: 0px 2px 5px rgba(0, 0, 255, 0.3), inset 0px -2px 3px rgba(0, 0, 0, 0.2);
+		border-radius: 3px;
+		position: relative;
+		transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+	  
+		&:hover {
+		  transform: scale(1.1);
+		  box-shadow: 0px 3px 8px rgba(0, 0, 255, 0.5);
+		}
     }
 
 	[component="post/replies/container"] {

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -13,8 +13,10 @@
 			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
 		</a>
 	</div>
-	{{{ if privileges.isAdminOrMod }}}
+	{{{ if posts.user.adminrole }}}
 		<div class="admin-star">Admin</div>
+	{{{ else }}}
+		<p>Admin role does not exist.</p>
 	{{{ end }}}
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -15,8 +15,6 @@
 	</div>
 	{{{ if posts.user.adminrole }}}
 		<div class="admin-star">Admin</div>
-	{{{ else }}}
-		<p>Admin role does not exist.</p>
 	{{{ end }}}
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -14,7 +14,7 @@
 		</a>
 	</div>
 	{{{ if posts.user.adminrole }}}
-		<div class="admin-star">Admin</div>
+		<div class="admin-star"></div>
 	{{{ end }}}
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -13,7 +13,7 @@
 			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
 		</a>
 	</div>
-	{{{ if privileges.isAdminOrMod}}}
+	{{{ if privileges.isAdminOrMod }}}
 		<div class="admin-star">Admin</div>
 	{{{ end }}}
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -37,9 +37,6 @@ PostObject:
         displayname:
           type: string
           description: This is either username or fullname depending on forum and user settings
-        adminrole:
-          type: string
-          description: This checks whether the poster is an admin or not
         userslug:
           type: string
           description: An URL-safe variant of the username (i.e. lower-cased, spaces

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -37,6 +37,9 @@ PostObject:
         displayname:
           type: string
           description: This is either username or fullname depending on forum and user settings
+        adminrole:
+          type: string
+          description: This checks whether the poster is an admin or not
         userslug:
           type: string
           description: An URL-safe variant of the username (i.e. lower-cased, spaces

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -47,6 +47,9 @@ TopicObject:
               type: string
               description: An URL-safe variant of the username (i.e. lower-cased, spaces
                 removed, etc.)
+            adminrole:
+              type: string
+              description: This checks whether the poster is an admin or not
             reputation:
               type: number
             postcount:
@@ -87,6 +90,7 @@ TopicObject:
             - status
             - icon:text
             - icon:bgColor
+            - adminrole
             - banned_until_readable
         teaser:
           type: object
@@ -101,6 +105,8 @@ TopicObject:
             tid:
               type: number
               description: A topic identifier
+            adminrole:
+              type: string
             content:
               type: string
             timestampISO:
@@ -178,6 +184,8 @@ TopicObject:
           description: A topic identifier
         thumb:
           type: string
+        adminrole:
+          type: string
         pinExpiry:
           type: number
           description: A UNIX timestamp indicating when a pinned topic will no longer be pinned (i.e. the pin has expired)
@@ -199,6 +207,8 @@ TopicObjectSlim:
         uid:
           type: number
           description: A user identifier
+        adminrole:
+          type: string
         cid:
           type: number
           description: A category identifier

--- a/public/openapi/components/schemas/admin/tokenObject.yaml
+++ b/public/openapi/components/schemas/admin/tokenObject.yaml
@@ -4,6 +4,9 @@ TokenObject:
     uid:
       type: number
       description: A valid user id
+    adminrole:
+      type: string
+      description: This checks whether the poster is an admin or not
     description:
       type: string
       description: Optional descriptor to differentiate tokens.

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -87,6 +87,8 @@ get:
                         user:
                           type: object
                           properties:
+                            adminrole:
+                              type: boolean
                             uid:
                               type: number
                               description: A user identifier

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -180,7 +180,7 @@ usersAPI.follow = async function (caller, data) {
 		toUid: data.uid,
 	});
 
-	const userData = await user.getUserFields(caller.uid, ['username', 'userslug','adminrole']);
+	const userData = await user.getUserFields(caller.uid, ['username', 'userslug', 'adminrole']);
 	const { displayname } = userData;
 
 	const notifObj = await notifications.create({

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -180,7 +180,7 @@ usersAPI.follow = async function (caller, data) {
 		toUid: data.uid,
 	});
 
-	const userData = await user.getUserFields(caller.uid, ['username', 'userslug']);
+	const userData = await user.getUserFields(caller.uid, ['username', 'userslug','adminrole']);
 	const { displayname } = userData;
 
 	const notifObj = await notifications.create({

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -22,18 +22,15 @@ module.exports = function (Categories) {
 				const isAdmin = await user.isAdministrator(topic.uid);
 				if (isAdmin) {
 					return 'Admin';
-				} else{
-					return 'user';
 				}
+				return 'user';
 			})
 		);
-		
 		topicsData.forEach((topic, index) => {
-			if (adminRole[index] == 'Admin'){
-				topic.adminrole = 'Admin'
-			}
-			else{
-				topic.adminrole = 'User'
+			if (adminRole[index] === 'Admin') {
+				topic.adminrole = 'Admin';
+			} else {
+				topic.adminrole = 'User';
 			}
 		});
 		if (!topicsData.length) {

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -16,6 +16,26 @@ module.exports = function (Categories) {
 		const tids = await Categories.getTopicIds(results);
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
 		topicsData = await user.blocks.filter(data.uid, topicsData);
+
+		const adminRole = await Promise.all(
+			topicsData.map(async (topic) => {
+				const isAdmin = await user.isAdministrator(topic.uid);
+				if (isAdmin) {
+					return 'Admin';
+				} else{
+					return 'user';
+				}
+			})
+		);
+		
+		topicsData.forEach((topic, index) => {
+			if (adminRole[index] == 'Admin'){
+				topic.adminrole = 'Admin'
+			}
+			else{
+				topic.adminrole = 'User'
+			}
+		});
 		if (!topicsData.length) {
 			return { topics: [], uid: data.uid };
 		}

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -13,11 +13,10 @@ userController.getCurrentUser = async function (req, res) {
 	const userslug = await user.getUserField(req.uid, 'userslug');
 	const userData = await accountHelpers.getUserDataByUserSlug(userslug, req.uid, req.query);
 	const isAdmin = await user.isAdministrator(req.uid);
-	let role = 'None'
-	if (isAdmin){
+	let role = 'None';
+	if (isAdmin) {
 		role = 'Admin';
-	}
-	else{
+	} else {
 		role = 'User';
 	}
 	res.json(userData);

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -12,7 +12,16 @@ userController.getCurrentUser = async function (req, res) {
 	}
 	const userslug = await user.getUserField(req.uid, 'userslug');
 	const userData = await accountHelpers.getUserDataByUserSlug(userslug, req.uid, req.query);
+	const isAdmin = await user.isAdministrator(req.uid);
+	let role = 'None'
+	if (isAdmin){
+		role = 'Admin';
+	}
+	else{
+		role = 'User';
+	}
 	res.json(userData);
+	userData.adminrole = role;
 };
 
 userController.getUserByUID = async function (req, res, next) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -1,4 +1,3 @@
- 
 'use strict';
 
 const _ = require('lodash');
@@ -108,7 +107,6 @@ module.exports = function (Topics) {
 			return [];
 		}
 		const pids = postData.map(post => post && post.pid);
-		
 		let outsideUids = null;
 		async function getPostUserData(field, method) {
 			const uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
@@ -126,7 +124,7 @@ module.exports = function (Topics) {
 			posts.hasBookmarked(pids, uid),
 			posts.getVoteStatusByPostIDs(pids, uid),
 			getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
-			getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug','isAdmin'])),
+			getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug', 'isAdmin'])),
 			getPostReplies(postData, uid),
 			Topics.addParentPosts(postData),
 		]);
@@ -141,7 +139,7 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-				outsideUids.forEach(i => {
+				outsideUids.forEach((i) => {
 					userData[String(i)].adminrole = userData[String(i)].groupTitle !== null;
 				});
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -140,9 +140,11 @@ module.exports = function (Topics) {
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
 				const isAdmin = user.isAdministrator(postObj.user);
-				postObj.user.adminrole = 'User';
 				if (isAdmin){
-					postObj.user.adminrole = 'Admin';
+					postObj.user.adminrole = true;
+				}
+				else{
+					postObj.user.adminrole =  false;
 				}
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -1,4 +1,4 @@
-
+ 
 'use strict';
 
 const _ = require('lodash');
@@ -139,11 +139,16 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-
+				const isAdmin = user.isAdministrator(postObj.user);
+				postObj.user.adminrole = 'User';
+				if (isAdmin){
+					postObj.user.adminrole = 'Admin';
+				}
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));
 					postObj.user.displayname = postObj.user.username;
+					postObj.user.adminrole = 'Guest';
 				}
 			}
 		});

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -108,10 +108,12 @@ module.exports = function (Topics) {
 			return [];
 		}
 		const pids = postData.map(post => post && post.pid);
-
+		
+		let outsideUids = null;
 		async function getPostUserData(field, method) {
 			const uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
 			const userData = await method(uids);
+			outsideUids = uids;
 			return _.zipObject(uids, userData);
 		}
 		const [
@@ -124,7 +126,7 @@ module.exports = function (Topics) {
 			posts.hasBookmarked(pids, uid),
 			posts.getVoteStatusByPostIDs(pids, uid),
 			getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
-			getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug'])),
+			getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug','isAdmin'])),
 			getPostReplies(postData, uid),
 			Topics.addParentPosts(postData),
 		]);
@@ -139,18 +141,12 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-				const isAdmin = user.isAdministrator(postObj.user);
-				if (isAdmin){
-					postObj.user.adminrole = true;
-				}
-				else{
-					postObj.user.adminrole =  false;
-				}
-				// Username override for guests, if enabled
+				outsideUids.forEach(i => {
+					userData[String(i)].adminrole = userData[String(i)].groupTitle !== null;
+				});
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));
 					postObj.user.displayname = postObj.user.username;
-					postObj.user.adminrole = 'Guest';
 				}
 			}
 		});

--- a/src/views/partials/data/category.tpl
+++ b/src/views/partials/data/category.tpl
@@ -1,1 +1,10 @@
-data-tid="{topics.tid}" data-index="{topics.index}" data-cid="{topics.cid}" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"
+<div data-tid="{topics.tid}" 
+     data-index="{topics.index}" 
+     data-cid="{topics.cid}" 
+     data-role="{topics.adminrole}" 
+     itemprop="itemListElement" 
+     itemscope 
+     itemtype="https://schema.org/ListItem">
+  <span class="badge bg-info text-white ms-2">
+    {topics.adminrole}
+  </span>

--- a/test/topics/events.js
+++ b/test/topics/events.js
@@ -93,7 +93,7 @@ describe('Topic Events', () => {
 			const isAdmin = await user.isAdministrator(topicData.user.uid);
 			if (isAdmin) {
 				role = 'Admin';
-			} 
+			}
 			assert.strictEqual(topicData.user.role, role);
 		});
 	});

--- a/test/topics/events.js
+++ b/test/topics/events.js
@@ -84,6 +84,20 @@ describe('Topic Events', () => {
 		});
 	});
 
+	describe('.checkAdmin()', () => {
+		it('this should make sure that the topic gets a proper tag', async () => {
+			const topicData = await topics.getTopic(topic.topicData.tid);
+			assert(topicData);
+			assert(topicData.user);
+			let role = 'user';
+			const isAdmin = await user.isAdministrator(topicData.user.uid);
+			if (isAdmin) {
+				role = 'Admin';
+			} 
+			assert.strictEqual(topicData.user.role, role);
+		});
+	});
+
 	describe('.purge()', () => {
 		let eventIds;
 


### PR DESCRIPTION
This resolves issue #31 by providing tags in the discussion board. To test you can create a post as a non admin and create a post as a normal user. It will look like this shown below:

![Screenshot 2025-02-24 at 9 31 26 PM](https://github.com/user-attachments/assets/d9140e35-3373-4db1-bb58-fee642dfa4bd)


Then I have also cleaned up the admin star code so only admins have a blue star next to their post/replies that indicate they are an admin.
![Screenshot 2025-02-24 at 9 34 14 PM](https://github.com/user-attachments/assets/623ad9ed-4bd6-41a3-bdfe-22c319049187)

Files Changed were:
nodebb-theme-harmony/scss/topic.scss
nodebb-theme-harmony/templates/partials/topic/post.tpl
public/openapi/components/schemas/TopicObject.yaml
public/openapi/components/schemas/admin/tokenObject.yaml
public/openapi/read/topic/topic_id.yaml
src/api/users.js
src/categories/topics.js
src/controllers/user.js
src/topics/posts.js
src/views/partials/data/category.tpl
test/topics/events.js



