### PR TITLE
Add StandardJS static analysis tool

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -35,6 +35,7 @@
         "@isaacs/ttlcache": "1.4.1",
         "@nodebb/spider-detector": "2.0.3",
         "@popperjs/core": "2.11.8",
+        "@socket.io/redis-adapter": "8.3.0",
         "ace-builds": "1.33.2",
         "archiver": "7.0.1",
         "async": "3.2.5",
@@ -75,6 +76,7 @@
         "helmet": "7.1.0",
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",
+        "ioredis": "5.4.1",
         "ipaddr.js": "2.2.0",
         "jquery": "3.7.1",
         "jquery-deserialize": "2.0.0",
@@ -120,7 +122,6 @@
         "postcss-clean": "1.2.0",
         "progress-webpack-plugin": "1.0.16",
         "prompt": "1.3.0",
-        "ioredis": "5.4.1",
         "rimraf": "5.0.7",
         "rss": "1.2.2",
         "rtlcss": "4.1.1",
@@ -132,7 +133,6 @@
         "sitemap": "7.1.1",
         "socket.io": "4.7.5",
         "socket.io-client": "4.7.5",
-        "@socket.io/redis-adapter": "8.3.0",
         "sortablejs": "1.15.2",
         "spdx-license-list": "6.9.0",
         "terser-webpack-plugin": "5.3.10",
@@ -169,7 +169,8 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
-        "smtp-server": "3.13.4"
+        "smtp-server": "3.13.4",
+        "standard": "^17.1.2"
     },
     "optionalDependencies": {
         "sass-embedded": "1.77.1"


### PR DESCRIPTION
Added [StandardJS](https://standardjs.com/).
Ran `npm install standard --save-dev ` in the `install/` directory to install `standard` locally.

Terminal output when running `npx standard`:

<img width="1110" alt="Screenshot 2025-03-12 at 12 55 23 PM" src="https://github.com/user-attachments/assets/c72b2687-b279-43f5-aa93-324d1e1ff2ce" />
