### PR TITLE
install stryker dynamic analysis tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ test.sh
 
 .docker/**
 !**/.gitkeep
+# stryker temp files
+.stryker-tmp

--- a/install/package.json
+++ b/install/package.json
@@ -35,6 +35,7 @@
         "@isaacs/ttlcache": "1.4.1",
         "@nodebb/spider-detector": "2.0.3",
         "@popperjs/core": "2.11.8",
+        "@socket.io/redis-adapter": "8.3.0",
         "ace-builds": "1.33.2",
         "archiver": "7.0.1",
         "async": "3.2.5",
@@ -75,6 +76,7 @@
         "helmet": "7.1.0",
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",
+        "ioredis": "5.4.1",
         "ipaddr.js": "2.2.0",
         "jquery": "3.7.1",
         "jquery-deserialize": "2.0.0",
@@ -120,7 +122,6 @@
         "postcss-clean": "1.2.0",
         "progress-webpack-plugin": "1.0.16",
         "prompt": "1.3.0",
-        "ioredis": "5.4.1",
         "rimraf": "5.0.7",
         "rss": "1.2.2",
         "rtlcss": "4.1.1",
@@ -132,7 +133,6 @@
         "sitemap": "7.1.1",
         "socket.io": "4.7.5",
         "socket.io-client": "4.7.5",
-        "@socket.io/redis-adapter": "8.3.0",
         "sortablejs": "1.15.2",
         "spdx-license-list": "6.9.0",
         "terser-webpack-plugin": "5.3.10",
@@ -156,6 +156,8 @@
         "@apidevtools/swagger-parser": "10.1.0",
         "@commitlint/cli": "19.3.0",
         "@commitlint/config-angular": "19.3.0",
+        "@stryker-mutator/core": "^8.7.1",
+        "@stryker-mutator/mocha-runner": "^8.7.1",
         "coveralls": "3.1.1",
         "eslint": "8.57.0",
         "eslint-config-nodebb": "0.2.1",
@@ -169,7 +171,8 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
-        "smtp-server": "3.13.4"
+        "smtp-server": "3.13.4",
+        "standard": "^17.1.2"
     },
     "optionalDependencies": {
         "sass-embedded": "1.77.1"

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
+  "packageManager": "npm",
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
+  "testRunner": "mocha",
+  "testRunner_comment": "Take a look at https://stryker-mutator.io/docs/stryker-js/mocha-runner for information about the mocha plugin.",
+  "mutate": ["src/**/*.js"],
+  "mochaOptions": {
+    "spec": ["test/**/*.js"]
+  },
+  "coverageAnalysis": "perTest"
+}


### PR DESCRIPTION
Added [StrykerJS](https://stryker-mutator.io/).
Ran following commands:
- `npm install --save-dev @stryker-mutator/core @stryker-mutator/mocha-runner`
- `npx stryker init` -- use mocha as the test runner

Created new file:
- `stryker.config.json` -- stores stryker config

Terminal output when running `npx stryker run`:
<img width="1206" alt="Screenshot 2025-03-12 at 8 26 32 PM" src="https://github.com/user-attachments/assets/543de316-a21b-429a-9b3e-d95318735273" />
